### PR TITLE
Lookup lock image size

### DIFF
--- a/scripts/i3lock-next
+++ b/scripts/i3lock-next
@@ -52,8 +52,14 @@ trap 'rm -f ${_image}' EXIT
 _i3lock_next_helper="${PREFIX}/${LIBDIR}/i3lock-next/i3lock-next-helper"
 _datetimecolor=$($_i3lock_next_helper ${_image} "${_font}"/"${_size}" "${_prompt}") # oops
 
-# get some values we need
+# get image width & height
 _wxh="$(${PREFIX}/${LIBDIR}/i3lock-next/image-size ${_image})"
+# get lock image size to calculate appropriate ring radius
+_lock_wxh="$(${PREFIX}/${LIBDIR}/i3lock-next/image-size ../share/i3lock-next/lock-dark.png)"
+_lock_w="${_lock_wxh%x*}"
+_lock_h="${_lock_wxh#*x}"
+_temp=$((_lock_w*_lock_w + _lock_h*_lock_h))
+_ring_radius="$(echo "$_temp" | python -c "import math; print int(1.1*math.sqrt(float(raw_input()))/2)")"
 
 # now call i3lock (should have i3lock-color installed)
 #  - with custom colours (such as fully transparent text - text is
@@ -79,6 +85,7 @@ i3lock -n -e -k                             \
     --insidevercolor=ffffff1c               \
     --insidewrongcolor=ffffff1c             \
     \
+    --radius="$_ring_radius"                \
     --ringcolor=0000001c                    \
     --ringvercolor=ffffff00                 \
     --ringwrongcolor=ffffff55               \

--- a/src/config.h
+++ b/src/config.h
@@ -45,11 +45,3 @@
  *
  */
 #define THRESHOLD 50
-
-/* LOCK_SIZE
- * Size of the lock image, in pixels
- * Assumes a square lock image
- * Default 80
- *
- */
-#define LOCK_SIZE 80

--- a/src/i3lock-next-helper.c
+++ b/src/i3lock-next-helper.c
@@ -323,13 +323,20 @@ int main(int argc, const char **argv)
         // draw prompt string just below the centre of the monitor
         imlib_text_draw(promptx, prompty, prompt);
 
+        // get width & height of lock image
+        imlib_context_set_image(lock);
+        int lock_width = imlib_image_get_width();
+        int lock_height = imlib_image_get_height();
+        // make sure to set context back to s
+        imlib_context_set_image(s);
+
         // set variables for lock image location on monitor
-        int lockx = widths[i] / 2 + xcoords[i] - LOCK_SIZE/2;
-        int locky = heights[i] / 2 + ycoords[i] - LOCK_SIZE/2;
+        int lockx = widths[i] / 2 + xcoords[i] - lock_width/2;
+        int locky = heights[i] / 2 + ycoords[i] - lock_height/2;
         D_PRINTF("Monitor %d: lock (x,y): (%d,%d)\n", i, lockx, locky);
 
         // draw lock image at the center of the monitor
-        imlib_blend_image_onto_image(lock, 0, 0, 0, LOCK_SIZE, LOCK_SIZE, lockx, locky, LOCK_SIZE, LOCK_SIZE);
+        imlib_blend_image_onto_image(lock, 0, 0, 0, lock_width, lock_height, lockx, locky, lock_width, lock_height);
     }
 
     // save the image and cleanup


### PR DESCRIPTION
This fixes #13 by looking up the lock image's size in:
* `src/i3lock-next-helper.c`: use lock image's size when blending onto blurred screenshot
* `scripts/i3lock-next`: use lock image's size to determine appropriate ring radius